### PR TITLE
claudeの認証情報の保存設定

### DIFF
--- a/.devcontainer/.claude/.gitignore
+++ b/.devcontainer/.claude/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore

--- a/.devcontainer/.gitignore
+++ b/.devcontainer/.gitignore
@@ -1,0 +1,1 @@
+.claude.json

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -37,7 +37,9 @@
   
   "mounts": [
     "source=${localWorkspaceFolder}/.devcontainer/flutter-cache,target=/root/.flutter,type=bind,consistency=cached",
-    "source=${localWorkspaceFolder}/.devcontainer/config/gh,target=/home/vscode/.config/gh,type=bind,consistency=cached"
+    "source=${localWorkspaceFolder}/.devcontainer/config/gh,target=/home/vscode/.config/gh,type=bind,consistency=cached",
+    "source=${localWorkspaceFolder}/.devcontainer/.claude,target=/home/vscode/.claude,type=bind,consistency=cached",
+    "source=${localWorkspaceFolder}/.devcontainer/.claude.json,target=/home/vscode/.claude.json,type=bind,consistency=cached"
   ],
 
   "remoteUser": "vscode",

--- a/README.md
+++ b/README.md
@@ -6,6 +6,17 @@ Destino is a game that brings healing and awareness of happiness to your life.
 
 ## For Developer
 
+### はじめに
+
+devcontainerに接続する前に、必ず以下のコマンドを実行すること
+
+```shell
+cd destino
+touch .devcontainer/.claude.json
+
+```
+
+
 ### コマンド
 
 ```shell


### PR DESCRIPTION
## Sourceryによるサマリー

Claude認証情報をdevcontainer内にローカル保存するためのドキュメント作成と設定。

ドキュメント:
- READMEに「はじめに」セクションを追加し、devcontainerに接続する前に.devcontainer/.claude.jsonファイルを作成する手順を記載。

雑務:
- .devcontainer/.claude/.gitignoreを導入し、認証情報ファイルがコミットされないようにする。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Document and configure local storage of Claude authentication credentials within the devcontainer.

Documentation:
- Add a “はじめに” section in README with instructions to create the .devcontainer/.claude.json file before connecting to the devcontainer.

Chores:
- Introduce a .devcontainer/.claude/.gitignore to ensure the credentials file is not committed.

</details>