### PR TITLE
プレイヤーを最前面に出す

### DIFF
--- a/life_game_app/devtools_options.yaml
+++ b/life_game_app/devtools_options.yaml
@@ -1,0 +1,3 @@
+description: This file stores settings for Dart & Flutter DevTools.
+documentation: https://docs.flutter.dev/tools/devtools/extensions#configure-extension-enablement-states
+extensions:

--- a/life_game_app/lib/game/my_world.dart
+++ b/life_game_app/lib/game/my_world.dart
@@ -27,6 +27,7 @@ class MyWorld extends World implements PlayerEventCallbacks {
   Future<void> onLoad() async {
     player = Player(position: Vector2.zero());
     player.eventCallbacks = this; // コールバックを設定
+    player.priority = 100; // プレイヤーを最前面に表示
     add(player);
 
     // 初期タイルを生成


### PR DESCRIPTION
Fixes #31

## Sourceryによる概要

プレイヤーのレンダリング優先度を調整して前面に表示し、devtools設定ファイルを追加

機能強化:
- プレイヤーのレンダリング優先度を100に設定し、他のオブジェクトの前面に表示されるようにした

その他の作業:
- DartとFlutter DevTools拡張機能を設定するために `devtools_options.yaml` を追加

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bring the player to the foreground by adjusting its render priority and add a devtools configuration file

Enhancements:
- Set player rendering priority to 100 so it appears in front of other objects

Chores:
- Add devtools_options.yaml to configure Dart & Flutter DevTools extensions

</details>