### PR TITLE
マップのタイルサイズを128x128にする

### DIFF
--- a/life_game_app/lib/constants/game_constants.dart
+++ b/life_game_app/lib/constants/game_constants.dart
@@ -1,7 +1,7 @@
 class GameConstants {
   // マップサイズの設定
   static const int mapSize = 100; // 100x100タイル = 10,000タイル
-  static const double tileSize = 100.0;
+  static const double tileSize = 128.0;
   static const int mapRadius = mapSize ~/ 2; // -50 to +50
   static const int renderDistance = 10; // 画面周辺のタイル描画距離
 


### PR DESCRIPTION
Fixes #34

## Sourceryによる要約

改善点:
- `tileSize`定数を100.0から128.0に増加させ、マップタイルを128×128ピクセルに変更します。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Enhancements:
- Increase tileSize constant from 100.0 to 128.0 to change map tiles to 128×128 pixels.

</details>