### PR TITLE
[Test] フェーズ1の統合テストとポリッシュ

### DIFF
--- a/life_game_app/test/widget_test.dart
+++ b/life_game_app/test/widget_test.dart
@@ -1,15 +1,21 @@
-// This is a basic Flutter widget test.
-//
-// To perform an interaction with a widget in your test, use the WidgetTester
-// utility in the flutter_test package. For example, you can send tap and scroll
-// gestures. You can also use WidgetTester to find child widgets in the widget
-// tree, read text, and verify that the values of widget properties are correct.
-
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
-
-import 'package:life_game_app/main.dart';
+import 'package:flame/game.dart';
+import 'package:life_game_app/game/my_game.dart';
 
 void main() {
-  testWidgets('Counter increments smoke test', (WidgetTester tester) async {});
+  testWidgets('Game widget renders without crashing', (WidgetTester tester) async {
+    final game = MyGame();
+    await tester.pumpWidget(
+      MaterialApp(
+        home: GameWidget<MyGame>.controlled(gameFactory: () => game),
+      ),
+    );
+
+    // 初期レンダリングを実行
+    await tester.pump(const Duration(milliseconds: 100));
+
+    // MaterialAppが存在することを確認
+    expect(find.byType(MaterialApp), findsOneWidget);
+  });
 }


### PR DESCRIPTION
Fixes #14
テストコードを追加

## Sourceryによる要約

MyGameゲームコンポーネントのウィジェットsmokeテストを追加し、デフォルトのFlutterカウンターテストのボイラープレートを削除します。

改善点:
- デフォルトのmain.dartの代わりに、FlameのGameとMyGameを使用するようにインポートを更新
- 自動生成されたFlutterウィジェットテストのコメントを削除

テスト:
- MyGameインスタンスを描画し、MaterialAppが存在することを確認するGameWidgetのレンダーsmokeテストを追加

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add a widget smoke test for the MyGame game component and remove the default Flutter counter test boilerplate.

Enhancements:
- Update imports to use Flame’s Game and MyGame instead of the default main.dart
- Remove autogenerated Flutter widget test comments

Tests:
- Add a GameWidget render smoke test that pumps the MyGame instance and verifies the MaterialApp is present

</details>