### PR TITLE
スコアシステムの実装

### DIFF
--- a/life_game_app/lib/components/arrival_counter.dart
+++ b/life_game_app/lib/components/arrival_counter.dart
@@ -2,18 +2,20 @@ import 'package:flame/components.dart';
 import 'package:flame/text.dart';
 import 'package:flutter/material.dart';
 
-import '../game/my_world.dart';
+import '../managers/score_manager.dart';
 
 /// シンプルな到達回数表示コンポーネント
-/// Camera.viewport に追加して画面に固定表示する想定
+/// `ScoreManager` を受け取り到達回数の変化時のみ表示を更新する
 class ArrivalCounter extends TextComponent {
-  final MyWorld world;
+  final ScoreManager scoreManager;
+  late final VoidCallback _listener;
 
-  ArrivalCounter({required this.world})
+  ArrivalCounter({required this.scoreManager})
     : super(
         position: Vector2(10, 10),
         anchor: Anchor.topLeft,
         priority: 200,
+        text: '到達: 0',
         textRenderer: TextPaint(
           style: const TextStyle(
             color: Colors.white,
@@ -21,12 +23,20 @@ class ArrivalCounter extends TextComponent {
             fontWeight: FontWeight.bold,
           ),
         ),
-      );
+      ) {
+    // 通知のコールバック
+    _listener = () {
+      text = '到達: ${scoreManager.arrivalCount}';
+    };
+    scoreManager.arrivalCountListenable.addListener(_listener);
+    // 初期表示
+    text = '到達: ${scoreManager.arrivalCount}';
+  }
 
   @override
-  void update(double dt) {
-    // 毎フレーム最新のカウントを表示
-    text = '到達: ${world.arrivalCount}';
-    super.update(dt);
+  void onRemove() {
+    // リスナーを解除
+    scoreManager.arrivalCountListenable.removeListener(_listener);
+    super.onRemove();
   }
 }

--- a/life_game_app/lib/game/my_game.dart
+++ b/life_game_app/lib/game/my_game.dart
@@ -73,7 +73,7 @@ class MyGame extends FlameGame with HasKeyboardHandlerComponents, TapCallbacks {
     camera.follow(myWorld.player);
 
     // 到達回数オーバーレイを追加
-    final arrivalCounter = ArrivalCounter(world: myWorld);
+    final arrivalCounter = ArrivalCounter(scoreManager: myWorld.scoreManager);
     camera.viewport.add(arrivalCounter);
 
     // MyWorldをリスナーとして登録

--- a/life_game_app/lib/game/my_world.dart
+++ b/life_game_app/lib/game/my_world.dart
@@ -10,6 +10,7 @@ import '../interfaces/player_events.dart';
 import '../interfaces/game_state_listener.dart';
 import '../constants/game_constants.dart';
 import '../managers/audio_manager.dart';
+import '../managers/score_manager.dart';
 import '../enums/game_state.dart';
 import '../generators/terrain_generator.dart';
 
@@ -20,8 +21,13 @@ class MyWorld extends World implements PlayerEventCallbacks, GameStateListener {
   bool _isPaused = false;
   final AudioManager _audioManager = AudioManager();
   final TerrainGenerator _terrainGenerator = TerrainGenerator();
-  // 到達回数を管理する
-  int arrivalCount = 0;
+  // スコア管理（到達回数など）
+  final ScoreManager scoreManager = ScoreManager();
+
+  // 公開用 getter/proxy
+  int get arrivalCount => scoreManager.arrivalCount;
+  ValueListenable<int> get arrivalListenable =>
+      scoreManager.arrivalCountListenable;
 
   // タイルキャッシュ
   final Map<String, TerrainTile> _tiles = {};
@@ -237,7 +243,7 @@ class MyWorld extends World implements PlayerEventCallbacks, GameStateListener {
     // 演出を表示
     showArrivalEffect(arrivalPosition);
     // 到達回数を増やす
-    arrivalCount += 1;
+    scoreManager.incrementArrivalCount();
     // 目的地をクリア
     clearDestination();
     // 新しい目的地を設定
@@ -263,7 +269,7 @@ class MyWorld extends World implements PlayerEventCallbacks, GameStateListener {
     clearDestination();
     setRandomDestination();
     // 到達回数をリセット
-    arrivalCount = 0;
+    scoreManager.resetArrivalCount();
   }
 
   // テスト用getter

--- a/life_game_app/lib/managers/score_manager.dart
+++ b/life_game_app/lib/managers/score_manager.dart
@@ -1,0 +1,23 @@
+import 'package:flutter/foundation.dart';
+
+/// 軽量なスコア管理クラス
+/// 将来的に到達時間や重み付きスコア等を追加するための拡張ポイント
+class ScoreManager {
+  final ValueNotifier<int> _arrivalCount = ValueNotifier<int>(0);
+
+  /// 到達回数の読み取り専用 Listenable
+  ValueListenable<int> get arrivalCountListenable => _arrivalCount;
+
+  /// 現在の到達回数
+  int get arrivalCount => _arrivalCount.value;
+
+  /// 到達回数を増やす（将来的に重みや時間をパラメータ化可能）
+  void incrementArrivalCount([int delta = 1]) {
+    _arrivalCount.value = _arrivalCount.value + delta;
+  }
+
+  /// 到達回数をリセット
+  void resetArrivalCount() {
+    _arrivalCount.value = 0;
+  }
+}

--- a/life_game_app/test/game/my_world_test.dart
+++ b/life_game_app/test/game/my_world_test.dart
@@ -199,7 +199,6 @@ void main() {
       // プレイヤーが目的地に向かって移動している
       expect(myWorld.player.velocity, isNot(Vector2.zero()));
     });
-    testWithFlameGame('resetで目的地到達回数がリセットされる', (game) async {});
     testWithFlameGame('resetで目的地到達回数がリセットされる', (game) async {
       // MyWorldをゲームに追加してロード
       await game.add(myWorld);

--- a/life_game_app/test/managers/score_manager_test.dart
+++ b/life_game_app/test/managers/score_manager_test.dart
@@ -1,0 +1,49 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:life_game_app/managers/score_manager.dart';
+
+void main() {
+  late ScoreManager scoreManager;
+
+  setUp(() {
+    scoreManager = ScoreManager();
+  });
+
+  test('initial arrivalCount is zero', () {
+    expect(scoreManager.arrivalCount, 0);
+  });
+
+  test('incrementArrivalCount increments and notifies once', () {
+    var notifiedCount = 0;
+    void listener() => notifiedCount++;
+
+    scoreManager.arrivalCountListenable.addListener(listener);
+    scoreManager.incrementArrivalCount(); // default +1
+    expect(scoreManager.arrivalCount, 1);
+    expect(notifiedCount, 1);
+
+    // cleanup
+    scoreManager.arrivalCountListenable.removeListener(listener);
+  });
+
+  test('incrementArrivalCount with delta works', () {
+    scoreManager.incrementArrivalCount(3);
+    expect(scoreManager.arrivalCount, 3);
+  });
+
+  test('resetArrivalCount resets to zero and notifies', () {
+    var notified = 0;
+    void listener() => notified++;
+
+    scoreManager.arrivalCountListenable.addListener(listener);
+    scoreManager.incrementArrivalCount(2);
+    expect(scoreManager.arrivalCount, 2);
+    expect(notified, 1);
+
+    scoreManager.resetArrivalCount();
+    expect(scoreManager.arrivalCount, 0);
+    // 実装により通知回数が変わる可能性があるため >= 2 を許容
+    expect(notified, greaterThanOrEqualTo(2));
+
+    scoreManager.arrivalCountListenable.removeListener(listener);
+  });
+}


### PR DESCRIPTION
Fixes #41

## Sourceryによる概要

MyWorldで到着を追跡し、画面上のカウンターを追加し、テストでその動作を検証することで、目的地到着スコアリングシステムを実装します。

新機能:
- MyWorldに目的地の到着を追跡するためのarrivalCountプロパティを追加
- プレイヤーが到着した際にarrivalCountをインクリメントし、ワールドがリセットされた際にリセットする
- ゲーム内で到着カウントオーバーレイをレンダリングするためのArrivalCounterコンポーネントを作成

改善点:
- 可読性向上のため、MyWorldテスト内の複数行のexpectアサーションを再フォーマット

テスト:
- 到着イベントでarrivalCountがインクリメントされ、ワールドリセットでリセットされることを検証するテストを追加

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Implement a destination arrival scoring system by tracking arrivals in MyWorld, adding an on-screen counter, and verifying its behavior with tests.

New Features:
- Add arrivalCount property in MyWorld to track destination arrivals
- Increment arrivalCount on player arrival and reset it when the world resets
- Create ArrivalCounter component to render the arrival count overlay in the game

Enhancements:
- Reformat multiline expect assertions in MyWorld tests for improved readability

Tests:
- Add tests to verify arrivalCount increments on arrival events and resets on world reset

</details>