### PR TITLE
デバッグ情報を固定表示してみる

### DIFF
--- a/life_game_app/lib/components/debug_overlay.dart
+++ b/life_game_app/lib/components/debug_overlay.dart
@@ -1,0 +1,122 @@
+import 'package:flame/components.dart';
+import 'package:flame/text.dart';
+import 'package:flutter/material.dart';
+import 'player.dart';
+
+/// デバッグ情報を画面にオーバーレイ表示するコンポーネント
+///
+/// 現在の表示項目:
+/// - プレイヤーの座標
+/// - 目的地の座標（設定されている場合）
+///
+/// 将来的に表示項目を拡張可能な設計
+class DebugOverlay extends PositionComponent {
+  final Player player;
+  late final TextComponent _playerPositionText;
+  late final TextComponent _destinationText;
+
+  // デバッグオーバーレイの表示/非表示を切り替えるフラグ
+  bool _isVisible = true;
+
+  DebugOverlay({required this.player})
+    : super(
+        position: Vector2(10, 40), // ArrivalCounterの下に配置
+        anchor: Anchor.topLeft,
+        priority: 200, // HUD層に表示
+      );
+
+  @override
+  Future<void> onLoad() async {
+    // プレイヤー座標のテキスト
+    _playerPositionText = TextComponent(
+      position: Vector2.zero(),
+      anchor: Anchor.topLeft,
+      textRenderer: TextPaint(
+        style: const TextStyle(
+          color: Colors.yellow,
+          fontSize: 14,
+          fontWeight: FontWeight.bold,
+        ),
+      ),
+    );
+    add(_playerPositionText);
+
+    // 目的地座標のテキスト
+    _destinationText = TextComponent(
+      position: Vector2(0, 20), // 1行下に配置
+      anchor: Anchor.topLeft,
+      textRenderer: TextPaint(
+        style: const TextStyle(
+          color: Colors.orange,
+          fontSize: 14,
+          fontWeight: FontWeight.bold,
+        ),
+      ),
+    );
+    add(_destinationText);
+  }
+
+  @override
+  void update(double dt) {
+    super.update(dt);
+
+    if (!_isVisible) {
+      return;
+    }
+
+    // プレイヤー座標を更新
+    _updatePlayerPosition();
+
+    // 目的地座標を更新
+    _updateDestination();
+  }
+
+  void _updatePlayerPosition() {
+    final x = player.position.x.toStringAsFixed(1);
+    final y = player.position.y.toStringAsFixed(1);
+    _playerPositionText.text = 'Player: ($x, $y)';
+  }
+
+  void _updateDestination() {
+    if (player.destination != null) {
+      final x = player.destination!.x.toStringAsFixed(1);
+      final y = player.destination!.y.toStringAsFixed(1);
+      _destinationText.text = 'Dest: ($x, $y)';
+    } else {
+      _destinationText.text = 'Dest: None';
+    }
+  }
+
+  /// デバッグオーバーレイの表示/非表示を切り替え
+  void toggleVisibility() {
+    _isVisible = !_isVisible;
+    _playerPositionText.text = _isVisible ? _playerPositionText.text : '';
+    _destinationText.text = _isVisible ? _destinationText.text : '';
+  }
+
+  /// デバッグオーバーレイを表示
+  void show() {
+    _isVisible = true;
+  }
+
+  /// デバッグオーバーレイを非表示
+  void hide() {
+    _isVisible = false;
+    _playerPositionText.text = '';
+    _destinationText.text = '';
+  }
+
+  /// 将来的にデバッグ項目を追加するためのメソッド例
+  ///
+  /// 使用例:
+  /// ```dart
+  /// void addDebugItem(String label, String Function() valueGetter) {
+  ///   final textComponent = TextComponent(
+  ///     position: Vector2(0, children.length * 20.0),
+  ///     anchor: Anchor.topLeft,
+  ///     textRenderer: TextPaint(...),
+  ///   );
+  ///   add(textComponent);
+  /// }
+  /// ```
+}

--- a/life_game_app/lib/game/my_game.dart
+++ b/life_game_app/lib/game/my_game.dart
@@ -4,6 +4,7 @@ import 'package:flame/events.dart';
 import 'package:flutter/services.dart';
 import 'my_world.dart';
 import '../components/arrival_counter.dart';
+import '../components/debug_overlay.dart';
 import '../managers/game_state_manager.dart';
 import '../enums/game_state.dart';
 import '../components/title_screen.dart';
@@ -75,6 +76,10 @@ class MyGame extends FlameGame with HasKeyboardHandlerComponents, TapCallbacks {
     // 到達回数オーバーレイを追加
     final arrivalCounter = ArrivalCounter(scoreManager: myWorld.scoreManager);
     camera.viewport.add(arrivalCounter);
+
+    // デバッグオーバーレイを追加
+    final debugOverlay = DebugOverlay(player: myWorld.player);
+    camera.viewport.add(debugOverlay);
 
     // MyWorldをリスナーとして登録
     stateManager.addListener(myWorld);


### PR DESCRIPTION
Fixes #40

## Sourceryによる要約

プレイヤーの現在位置と目的地座標をリアルタイムで表示する永続的なデバッグオーバーレイをゲームに追加します。

新機能:
- プレイヤーと目的地座標をオーバーレイとしてレンダリングするためのDebugOverlayコンポーネントを導入
- 到着カウンターの下にDebugOverlayをゲームのビューポートに自動的に追加

バグ修正:
- 固定された画面上のデバッグ表示を提供することで #40 を修正

改善点:
- トグルおよび表示コントロール、および将来のデバッグ項目を追加するためのフックを提供

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add a persistent debug overlay to the game that displays the player’s current position and destination coordinates in real time.

New Features:
- Introduce DebugOverlay component for rendering player and destination coordinates as overlay
- Automatically add DebugOverlay to the game viewport beneath the arrival counter

Bug Fixes:
- Fix #40 by providing a fixed on-screen debug display

Enhancements:
- Provide toggle and visibility controls and a hook for adding future debug items

</details>