### PR TITLE
constants.dartをconfig.dartに変更する

### DIFF
--- a/life_game_app/lib/src/components/background_tile.dart
+++ b/life_game_app/lib/src/components/background_tile.dart
@@ -1,13 +1,13 @@
 import 'package:flame/components.dart';
 import 'package:flutter/material.dart';
-import '../constants/game_constants.dart';
+import '../config.dart';
 
 class BackgroundTile extends RectangleComponent with HasGameReference {
   final int gridX;
   final int gridY;
 
   BackgroundTile({super.position, required this.gridX, required this.gridY})
-    : super(size: Vector2.all(GameConstants.tileSize), anchor: Anchor.center);
+    : super(size: Vector2.all(Config.tileSize), anchor: Anchor.center);
 
   @override
   Future<void> onLoad() async {

--- a/life_game_app/lib/src/components/player.dart
+++ b/life_game_app/lib/src/components/player.dart
@@ -1,6 +1,6 @@
 import 'package:flame/components.dart';
 import 'package:flutter/services.dart';
-import '../constants/game_constants.dart';
+import '../config.dart';
 import '../interfaces/player_events.dart';
 
 class Player extends SpriteComponent {
@@ -10,7 +10,7 @@ class Player extends SpriteComponent {
   PlayerEventCallbacks? eventCallbacks;
 
   Player({super.position})
-    : super(size: Vector2.all(GameConstants.playerSize), anchor: Anchor.center);
+    : super(size: Vector2.all(Config.playerSize), anchor: Anchor.center);
 
   @override
   Future<void> onLoad() async {
@@ -43,10 +43,10 @@ class Player extends SpriteComponent {
     double distance = direction.length;
 
     // 目的地の到達判定
-    if (distance > GameConstants.arrivalThreshold) {
+    if (distance > Config.arrivalThreshold) {
       // 正規化された方向ベクトルを計算
       direction.normalize();
-      velocity = direction * GameConstants.playerSpeed;
+      velocity = direction * Config.playerSpeed;
     } else {
       // 目的地に到達
       final arrivalPosition = position.clone();
@@ -60,7 +60,7 @@ class Player extends SpriteComponent {
     final newPosition = position + velocity * dt;
 
     // マップ境界チェック
-    final mapBounds = GameConstants.mapRadius * GameConstants.tileSize;
+    final mapBounds = Config.mapRadius * Config.tileSize;
     final clampedPosition = Vector2(
       newPosition.x.clamp(-mapBounds + size.x / 2, mapBounds - size.x / 2),
       newPosition.y.clamp(-mapBounds + size.y / 2, mapBounds - size.y / 2),

--- a/life_game_app/lib/src/components/terrain_tile.dart
+++ b/life_game_app/lib/src/components/terrain_tile.dart
@@ -1,6 +1,6 @@
 import 'package:flame/components.dart';
 import 'package:flutter/material.dart';
-import '../constants/game_constants.dart';
+import '../config.dart';
 import '../terrain/terrain_type.dart';
 
 class TerrainTile extends SpriteComponent with HasGameReference {
@@ -13,7 +13,7 @@ class TerrainTile extends SpriteComponent with HasGameReference {
     required this.gridX,
     required this.gridY,
     required this.terrainType,
-  }) : super(size: Vector2.all(GameConstants.tileSize), anchor: Anchor.center);
+  }) : super(size: Vector2.all(Config.tileSize), anchor: Anchor.center);
 
   @override
   Future<void> onLoad() async {

--- a/life_game_app/lib/src/components/title_screen.dart
+++ b/life_game_app/lib/src/components/title_screen.dart
@@ -1,6 +1,6 @@
 import 'package:flame/components.dart';
 import 'package:flutter/material.dart';
-import '../constants/game_constants.dart';
+import '../config.dart';
 
 class TitleScreen extends PositionComponent {
   TitleScreen({super.position, super.size});
@@ -9,7 +9,7 @@ class TitleScreen extends PositionComponent {
   Future<void> onLoad() async {
     // タイトルテキスト
     final titleText = TextComponent(
-      text: GameConstants.gameTitle,
+      text: Config.gameTitle,
       textRenderer: TextPaint(
         style: const TextStyle(
           fontSize: 64,

--- a/life_game_app/lib/src/config.dart
+++ b/life_game_app/lib/src/config.dart
@@ -1,7 +1,6 @@
-class GameConstants {
+class Config {
   // ゲームの名前
   static const String gameTitle = 'DESTINO';
-
   // マップサイズの設定
   static const int mapSize = 100; // 100x100タイル = 10,000タイル
   static const double tileSize = 128.0;

--- a/life_game_app/lib/src/game/game_menu_drawer.dart
+++ b/life_game_app/lib/src/game/game_menu_drawer.dart
@@ -1,6 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:life_game_app/src/my_game.dart';
-import '../constants/game_constants.dart';
+import '../config.dart';
 
 class GameMenuDrawer extends StatelessWidget {
   final MyGame game;
@@ -21,7 +21,7 @@ class GameMenuDrawer extends StatelessWidget {
               mainAxisAlignment: MainAxisAlignment.end,
               children: [
                 Text(
-                  GameConstants.gameTitle,
+                  Config.gameTitle,
                   style: TextStyle(
                     color: Colors.white,
                     fontSize: 32,

--- a/life_game_app/lib/src/game/my_world.dart
+++ b/life_game_app/lib/src/game/my_world.dart
@@ -8,7 +8,7 @@ import '../components/arrival_effect.dart';
 import '../components/bloom_effect.dart';
 import '../interfaces/player_events.dart';
 import 'game_state_listener.dart';
-import '../constants/game_constants.dart';
+import '../config.dart';
 import '../managers/audio_manager.dart';
 import '../managers/score_manager.dart';
 import 'game_state.dart';
@@ -60,8 +60,8 @@ class MyWorld extends World implements PlayerEventCallbacks, GameStateListener {
     }
 
     // プレイヤーの現在のタイル座標を計算
-    final currentTileX = (player.position.x / GameConstants.tileSize).floor();
-    final currentTileY = (player.position.y / GameConstants.tileSize).floor();
+    final currentTileX = (player.position.x / Config.tileSize).floor();
+    final currentTileY = (player.position.y / Config.tileSize).floor();
 
     // タイル位置が変化した場合のみ可視タイルを更新
     if (currentTileX != _lastPlayerTileX || currentTileY != _lastPlayerTileY) {
@@ -73,25 +73,25 @@ class MyWorld extends World implements PlayerEventCallbacks, GameStateListener {
 
   void _updateVisibleTiles() {
     // プレイヤーの現在位置からタイル座標を計算
-    final playerTileX = (player.position.x / GameConstants.tileSize).round();
-    final playerTileY = (player.position.y / GameConstants.tileSize).round();
+    final playerTileX = (player.position.x / Config.tileSize).round();
+    final playerTileY = (player.position.y / Config.tileSize).round();
 
     // 現在表示すべきタイルの範囲
-    final minX = (playerTileX - GameConstants.renderDistance).clamp(
-      -GameConstants.mapRadius,
-      GameConstants.mapRadius,
+    final minX = (playerTileX - Config.renderDistance).clamp(
+      -Config.mapRadius,
+      Config.mapRadius,
     );
-    final maxX = (playerTileX + GameConstants.renderDistance).clamp(
-      -GameConstants.mapRadius,
-      GameConstants.mapRadius,
+    final maxX = (playerTileX + Config.renderDistance).clamp(
+      -Config.mapRadius,
+      Config.mapRadius,
     );
-    final minY = (playerTileY - GameConstants.renderDistance).clamp(
-      -GameConstants.mapRadius,
-      GameConstants.mapRadius,
+    final minY = (playerTileY - Config.renderDistance).clamp(
+      -Config.mapRadius,
+      Config.mapRadius,
     );
-    final maxY = (playerTileY + GameConstants.renderDistance).clamp(
-      -GameConstants.mapRadius,
-      GameConstants.mapRadius,
+    final maxY = (playerTileY + Config.renderDistance).clamp(
+      -Config.mapRadius,
+      Config.mapRadius,
     );
 
     // 現在表示すべきタイルのセット
@@ -121,10 +121,7 @@ class MyWorld extends World implements PlayerEventCallbacks, GameStateListener {
           //   gridY: j,
           // );
           final tile = TerrainTile(
-            position: Vector2(
-              i * GameConstants.tileSize,
-              j * GameConstants.tileSize,
-            ),
+            position: Vector2(i * Config.tileSize, j * Config.tileSize),
             gridX: i,
             gridY: j,
             terrainType: terrainType,
@@ -182,7 +179,7 @@ class MyWorld extends World implements PlayerEventCallbacks, GameStateListener {
     );
 
     // マップ境界内にクランプ
-    final mapBounds = GameConstants.mapRadius * GameConstants.tileSize;
+    final mapBounds = Config.mapRadius * Config.tileSize;
     final clampedTarget = Vector2(
       randomTarget.x.clamp(-mapBounds, mapBounds),
       randomTarget.y.clamp(-mapBounds, mapBounds),


### PR DESCRIPTION
Fixes #57

## Sourceryによる要約

定数ファイルとクラスの名前をGameConstantsからConfigに変更し、それに伴い、すべてのインポートと参照を更新します

改善点:
- 定数ファイル game_constants.dart を config.dart に名前変更
- GameConstants クラスの名前を Config に変更し、コードベース全体でその参照を更新

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Rename the constants file and class from GameConstants to Config and update all imports and references accordingly

Enhancements:
- Rename constants file game_constants.dart to config.dart
- Rename GameConstants class to Config and update its references throughout the codebase

</details>